### PR TITLE
ShellScript課題3　修正版

### DIFF
--- a/calc3x.sh
+++ b/calc3x.sh
@@ -8,55 +8,63 @@
 #1行ファイル出力後に処理を続けるかどうかの確認を行い、終了するまでループする。
 #---------------------------------------------------------------------
 
-#ファイルを作成する。
-function make_file() {
+readonly TRUE=0
+readonly FALSE=1
+
+#ファイル名を作成する。
+function generate_file_name() {
 	local datetime=$(date "+%Y%m%d_%H%M%S")
 	local file_name="output_${datetime}.tsv"
 	echo "$file_name"
 }
 
 #ユーザーから文字列の入力を受け付ける。
-function get_text(){
-	echo -n "文字列を入力してください:"
+#リダイレクトを行わないと、「文字列を入力してください:」がファイルに出力されるため、標準出力エラーを利用している。
+#「1>&2」:標準出力(1)の出力先を標準エラー出力(2)と同じところに設定する。
+function accept_user_input(){
+	echo -n "文字列を入力してください:" 1>&2
 	read user_input
+	echo "$user_input"
 }
 
-#文字列と一緒にファイルに出力される現在日時を取得する。
-function get_current_datetime(){
-	current_datetime=$(date "+%Y-%m-%d %H:%M:%S.%3N")
+#ファイルへ出力する1行を成形する。
+function shape_output_line(){
+	local user_input=$1
+	local current_datetime=$(date "+%Y-%m-%d %H:%M:%S.%3N")
+	echo -en "${current_datetime}\t${user_input}\n"
 }
 
-#日時と文字列をtsvファイルへ出力する。
-function write() {
+#成形した1行をtsvファイルへ出力する。
+function write_file() {
 	local file_name=$1
-	local datetime=$2
-	local user_input=$3
-	echo -en "${current_datetime}\t${user_input}\\n" >> "$file_name"
+	local output_line=$2
+	echo "$output_line" >> "$file_name"
+	echo "ファイルへ書き込みました。"
 }
 
 #ユーザーの回答が"Y"または"N"であるかをチェックする。
-#入力が正しければ0を、正しくなければ1を戻り値として返す。
-function check_continue_response() {
-	local continue_response=$1
-	if [[ ! "$continue_response" =~ ^[YN]$ ]]; then
-		return 1
+#入力が正しければTRUEを、正しくなければFALSEを戻り値として返す。
+function check_user_response() {
+	local user_response=$1
+	if [[ ! "$user_response" =~ ^[YN]$ ]]; then
+		return $FALSE
 	fi
-	return 0
+	return $TRUE
 }
 
 #入力を続けるかどうか確認する。
-#continue_responseにYが入力されたとき0を、Nが入力されたとき1を戻り値として返す。
-function ask_continue() {
+#user_responseにYが入力されたときTRUEを、Nが入力されたときFALSEを戻り値として返す。
+function confirm_if_continue() {
 	while :; do
 		echo -n '入力を続けますか？続ける場合は"Y"、終了する場合は"N"を入力してください:'
-		read continue_response
-		check_continue_response "$continue_response"
+		read user_response
+		check_user_response "$user_response"
 		local return_value=$?
-		if [[ $return_value -eq 0 ]]; then
-			if [[ "$continue_response" = "Y" ]]; then
-				return 0
-			elif [[ "$continue_response" = "N" ]]; then
-				return 1
+		if [[ $return_value = $TRUE ]]; then
+			if [[ "$user_response" = "Y" ]]; then
+				return $TRUE
+			elif [[ "$user_response" = "N" ]]; then
+				return $FALSE
 			fi
 		else
 			echo "入力が正しくありません。もう一度入力してください。"
@@ -65,16 +73,22 @@ function ask_continue() {
 }
 
 #メイン処理
-#ask_continueの戻り値が0の場合は計算を繰り返し、1の場合はスクリプトを終了する。
-file_name=$(make_file)
-continue_program=0
-while [ "$continue_program" -eq 0 ]; do
-	get_text
-	get_current_datetime
-	write "$file_name" "$current_datetime" "$user_input"
-	echo "ファイルへ書き込みました。"
-	ask_continue
-	continue_program=$?
+#ask_continueの戻り値がTRUEの場合は計算を繰り返し、FALSEの場合はスクリプトを終了する。
+file_name=$(generate_file_name)
+isContinue=$TRUE
+while [ "$isContinue" = $TRUE ]; do
+	#入力を受け付ける
+	user_input=$(accept_user_input)
+
+	#ファイルへ出力する1行を成形する
+	output_line=$(shape_output_line "$user_input")
+
+	#ファイルへ出力する
+	write_file "$file_name" "$output_line"
+
+	#入力を続けるかどうか確認する。
+	confirm_if_continue
+	isContinue=$?
 done
 echo "スクリプトを終了します。"
 exit 0

--- a/calc3x.sh
+++ b/calc3x.sh
@@ -27,14 +27,14 @@ function accept_user_input(){
 	echo "$user_input"
 }
 
-#ファイルへ出力する1行を成形する。
-function shape_output_line(){
+#ファイルへ出力する1行を整形する。
+function format_output_line(){
 	local user_input=$1
 	local current_datetime=$(date "+%Y-%m-%d %H:%M:%S.%3N")
 	echo -en "${current_datetime}\t${user_input}\n"
 }
 
-#成形した1行をtsvファイルへ出力する。
+#整形した1行をtsvファイルへ出力する。
 function write_file() {
 	local file_name=$1
 	local output_line=$2
@@ -75,20 +75,20 @@ function confirm_if_continue() {
 #メイン処理
 #ask_continueの戻り値がTRUEの場合は計算を繰り返し、FALSEの場合はスクリプトを終了する。
 file_name=$(generate_file_name)
-isContinue=$TRUE
-while [ "$isContinue" = $TRUE ]; do
+is_continue=$TRUE
+while [ "$is_continue" = $TRUE ]; do
 	#入力を受け付ける
 	user_input=$(accept_user_input)
 
-	#ファイルへ出力する1行を成形する
-	output_line=$(shape_output_line "$user_input")
+	#ファイルへ出力する1行を整形する
+	output_line=$(format_output_line "$user_input")
 
 	#ファイルへ出力する
 	write_file "$file_name" "$output_line"
 
 	#入力を続けるかどうか確認する。
 	confirm_if_continue
-	isContinue=$?
+	is_continue=$?
 done
 echo "スクリプトを終了します。"
 exit 0


### PR DESCRIPTION
【概要】
キーボードで入力した文字列をテキストファイルの最終行に出力する。
テキストファイルには「日時{タブ文字}キーボードで入力した文字列」のように出力し、日時のフォーマットは「2024-07-01 00:11:22.333」とする。
出力ファイルの文字コードはUTF-8、改行コードはLFとし、ファイル名は「output_20240701_001122.tsv」のように「固定部分_日付_時分秒」とする。
テキストファイルへの出力後に処理を続けるかどうかの確認を行い、終了するまでループを行う。

【詳細】
- 関数generate__file_nameでファイル名を作成し、戻り値として作成されたファイル名を変数file_nameに代入する。
- 関数accept_user_inputでユーザーからの文字列の入力を受け付け、戻り値として変数user_inputに代入する。
- 関数format_output_lineに引数としてuser_inputを渡し、現在日時とユーザーが入力した文字列を指定されたフォーマット通りに整形する。整形した1行は変数output_lineに代入する。
- 関数write_fileの引数としてfile_name、output_lineを渡し、ファイルに出力する。
- 関数confirm_if_continueでユーザーに入力を続けるか尋ねる。
　- confirm_if_continueの中で関数check_user_responseを呼び出し、続ける/終了するを表すY/Nの入力が正しいかチェックする。入力が正しければ戻り値TRUEを返し、正しくなければ戻り値FALSEを返す。
　- check_user_responseがFALSEだったときはループの最初に戻って再度続けるかどうか尋ねる。TRUEだった場合は条件分岐を行い、入力されたのがYならTRUEを、NならFALSEを呼び出し元に返す。
- 関数confirm_if_continueの戻り値をis_continueというフラグに代入し、is_continueがTRUEなら文字列の入力から処理を繰り返し、is_continueがFALSEならメイン処理のループを抜け、スクリプトを終了する。

【レビュー後修正点】
1. 関数名、変数名がわかりにくかったため修正した。
2. コメントが処理にあっていなかったため修正した。
3. 関数の実行結果をechoで返している部分と、グローバル変数で取得している部分が混在していたため、echoで返すよう統一した。
4. get_current_datetimeを削除し、ファイル出力する1行を整形する関数shape_output_lineを定義した。
5. 改行コードの指定を「//n」から「/n」に修正した。
6. 関数の戻り値を0と1にしていたがわかりにくいため、0をTRUE、1をFALSEという定数にした。
7. メイン処理のループを続けるかどうかのフラグがわかりにくいため、「continue_program」から「isContinue」にした。⇒9.で再修正した。
8. 変数shape_output_lineをformat_output_lineに修正した。
9. 変数isContinueをキャメルケースからスネークケースに修正した。
10. 「成形」を「整形」に修正した。